### PR TITLE
OpenSpec: Standardize Terraform resource naming

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -7,6 +7,11 @@ on:
 
   workflow_dispatch:
     inputs:
+      deployment_name:
+        description: "Unique deployment name (e.g., sleap-lablink). Used as prefix for all AWS resources."
+        required: true
+        default: "my-lablink"
+        type: string
       environment:
         description: "Environment to deploy (test, prod, or ci-test) - dev uses local state and should only be used locally"
         required: true
@@ -47,6 +52,16 @@ jobs:
       - name: Determine Environment
         id: setenv
         run: |
+          # Set deployment_name from input or use default
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            DEPLOYMENT_NAME="${{ github.event.inputs.deployment_name }}"
+          else
+            # For automatic triggers, use repository variable or default
+            DEPLOYMENT_NAME="${{ vars.DEPLOYMENT_NAME || 'my-lablink' }}"
+          fi
+          echo "deployment_name=${DEPLOYMENT_NAME}" >> "$GITHUB_OUTPUT"
+
+          # Set environment
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             case "${{ github.event.inputs.environment }}" in
               test|prod|ci-test)
@@ -71,6 +86,7 @@ jobs:
 
       - name: Debug Environment
         run: |
+          echo "Deployment name: ${{ steps.setenv.outputs.deployment_name }}"
           echo "Using environment: ${{ steps.setenv.outputs.env }}"
           echo "Working directory: ${{ steps.setenv.outputs.workdir }}"
 
@@ -157,14 +173,16 @@ jobs:
         working-directory: ${{ steps.setenv.outputs.workdir }}
         run: |
           terraform plan \
-            -var="resource_suffix=${{ steps.setenv.outputs.env }}"
+            -var="deployment_name=${{ steps.setenv.outputs.deployment_name }}" \
+            -var="environment=${{ steps.setenv.outputs.env }}"
 
       - name: Terraform Apply
         id: apply
         working-directory: ${{ steps.setenv.outputs.workdir }}
         run: |
           terraform apply -auto-approve \
-            -var="resource_suffix=${{ steps.setenv.outputs.env }}"
+            -var="deployment_name=${{ steps.setenv.outputs.deployment_name }}" \
+            -var="environment=${{ steps.setenv.outputs.env }}"
         continue-on-error: true
 
       - name: Save PEM Key to Artifact
@@ -212,4 +230,4 @@ jobs:
       - name: Terraform Destroy on Failure
         working-directory: ${{ steps.setenv.outputs.workdir }}
         if: steps.apply.outcome == 'failure'
-        run: terraform destroy -auto-approve -var="resource_suffix=${{ steps.setenv.outputs.env }}"
+        run: terraform destroy -auto-approve -var="deployment_name=${{ steps.setenv.outputs.deployment_name }}" -var="environment=${{ steps.setenv.outputs.env }}"

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -8,6 +8,11 @@ on:
         required: true
         default: "no"
         type: string
+      deployment_name:
+        description: "Unique deployment name (must match the deployment to destroy)"
+        required: true
+        default: "my-lablink"
+        type: string
       environment:
         description: "Environment to destroy (test, prod, or ci-test) - dev uses local state and should only be used locally"
         required: true
@@ -107,4 +112,5 @@ jobs:
         working-directory: lablink-infrastructure
         run: |
           terraform destroy -auto-approve \
-            -var="resource_suffix=${{ github.event.inputs.environment }}"
+            -var="deployment_name=${{ github.event.inputs.deployment_name }}" \
+            -var="environment=${{ github.event.inputs.environment }}"

--- a/lablink-infrastructure/README.md
+++ b/lablink-infrastructure/README.md
@@ -481,7 +481,7 @@ cp config/example.config.yaml config/config.yaml  # if not already created
 ../scripts/init-terraform.sh test   # S3 backend
 
 # 4. Deploy (or have an existing deployment)
-terraform apply -var="resource_suffix=dev"
+terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=dev"
 ```
 
 **Running verification:**

--- a/lablink-infrastructure/alb.tf
+++ b/lablink-infrastructure/alb.tf
@@ -11,7 +11,7 @@ data "aws_vpc" "default" {
 # NOTE: Security group must be in the same VPC as the ALB. Using default VPC.
 resource "aws_security_group" "alb_sg" {
   count  = local.create_alb ? 1 : 0
-  name   = "lablink-alb-sg-${var.resource_suffix}"
+  name   = "${var.deployment_name}-alb-sg-${var.environment}"
   vpc_id = data.aws_vpc.default[0].id
 
   ingress {
@@ -38,10 +38,9 @@ resource "aws_security_group" "alb_sg" {
     description = "Allow all outbound traffic"
   }
 
-  tags = {
-    Name        = "lablink-alb-sg-${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-alb-sg-${var.environment}"
+  })
 }
 
 # Update allocator security group to allow traffic from ALB
@@ -68,7 +67,7 @@ data "aws_subnets" "default" {
 # Application Load Balancer
 resource "aws_lb" "allocator_alb" {
   count              = local.create_alb ? 1 : 0
-  name               = "lablink-alb-${var.resource_suffix}"
+  name               = "${var.deployment_name}-alb-${var.environment}"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [aws_security_group.alb_sg[0].id]
@@ -76,16 +75,15 @@ resource "aws_lb" "allocator_alb" {
 
   enable_deletion_protection = false
 
-  tags = {
-    Name        = "lablink-alb-${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-alb-${var.environment}"
+  })
 }
 
 # Target group for allocator EC2 instance
 resource "aws_lb_target_group" "allocator_tg" {
   count    = local.create_alb ? 1 : 0
-  name     = "lablink-tg-${var.resource_suffix}"
+  name     = "${var.deployment_name}-alb-tg-${var.environment}"
   port     = 5000
   protocol = "HTTP"
   vpc_id   = data.aws_vpc.default[0].id
@@ -102,10 +100,9 @@ resource "aws_lb_target_group" "allocator_tg" {
     unhealthy_threshold = 2
   }
 
-  tags = {
-    Name        = "lablink-tg-${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-alb-tg-${var.environment}"
+  })
 }
 
 # Attach allocator EC2 instance to target group

--- a/lablink-infrastructure/backend-ci-test.hcl
+++ b/lablink-infrastructure/backend-ci-test.hcl
@@ -5,19 +5,19 @@
 #
 # Usage (Local):
 #   ../scripts/init-terraform.sh ci-test  # Reads bucket from config/config.yaml (once supported)
-#   terraform plan -var="resource_suffix=ci-test"
-#   terraform apply -var="resource_suffix=ci-test"
+#   terraform plan -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=ci-test"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=ci-test"
 #
 # Usage (Manual):
 #   terraform init -backend-config=backend-ci-test.hcl -backend-config="bucket=YOUR-BUCKET"
-#   terraform plan -var="resource_suffix=ci-test"
-#   terraform apply -var="resource_suffix=ci-test"
+#   terraform plan -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=ci-test"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=ci-test"
 #
 # Usage (GitHub Actions):
 #   Deploy LabLink Infrastructure -> Choose environment: ci-test
 #   Destroy LabLink Infrastructure -> Choose environment: ci-test
 #
-# Resource naming: All resources suffixed with -ci-test (e.g., lablink-eip-ci-test)
+# Resource naming: {deployment_name}-{resource-type}-ci-test (e.g., sleap-lablink-eip-ci-test)
 # This allows simultaneous deployments alongside test/prod environments
 key            = "ci-test/terraform.tfstate"
 dynamodb_table = "lock-table"

--- a/lablink-infrastructure/backend-dev.hcl
+++ b/lablink-infrastructure/backend-dev.hcl
@@ -5,16 +5,16 @@
 #
 # Usage (Local):
 #   ../scripts/init-terraform.sh dev
-#   terraform plan -var="resource_suffix=dev"
-#   terraform apply -var="resource_suffix=dev"
+#   terraform plan -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=dev"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=dev"
 #
 # Usage (Manual):
 #   terraform init -backend-config=backend-dev.hcl
-#   terraform plan -var="resource_suffix=dev"
-#   terraform apply -var="resource_suffix=dev"
+#   terraform plan -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=dev"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=dev"
 #
 # Usage (GitHub Actions):
 #   NOT AVAILABLE - Local development only
 #
 # Note: Not suitable for team collaboration or CI/CD
-# Resource naming: All resources suffixed with -dev (e.g., lablink-eip-dev)
+# Resource naming: {deployment_name}-{resource-type}-dev (e.g., sleap-lablink-eip-dev)

--- a/lablink-infrastructure/backend-prod.hcl
+++ b/lablink-infrastructure/backend-prod.hcl
@@ -4,19 +4,19 @@
 #
 # Usage (Local):
 #   ../scripts/init-terraform.sh prod  # Reads bucket from config/config.yaml
-#   terraform plan -var="resource_suffix=prod"
-#   terraform apply -var="resource_suffix=prod"
+#   terraform plan -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=prod"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=prod"
 #
 # Usage (Manual):
 #   terraform init -backend-config=backend-prod.hcl -backend-config="bucket=YOUR-BUCKET"
-#   terraform plan -var="resource_suffix=prod"
-#   terraform apply -var="resource_suffix=prod"
+#   terraform plan -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=prod"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=prod"
 #
 # Usage (GitHub Actions):
 #   Workflow: Deploy LabLink Infrastructure
 #   Choose environment: prod
 #
-# Resource naming: All resources suffixed with -prod (e.g., lablink-eip-prod)
+# Resource naming: {deployment_name}-{resource-type}-prod (e.g., sleap-lablink-eip-prod)
 key            = "prod/terraform.tfstate"
 dynamodb_table = "lock-table"
 encrypt        = true

--- a/lablink-infrastructure/backend-test.hcl
+++ b/lablink-infrastructure/backend-test.hcl
@@ -4,19 +4,19 @@
 #
 # Usage (Local):
 #   ../scripts/init-terraform.sh test  # Reads bucket from config/config.yaml
-#   terraform plan -var="resource_suffix=test"
-#   terraform apply -var="resource_suffix=test"
+#   terraform plan -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=test"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=test"
 #
 # Usage (Manual):
 #   terraform init -backend-config=backend-test.hcl -backend-config="bucket=YOUR-BUCKET"
-#   terraform plan -var="resource_suffix=test"
-#   terraform apply -var="resource_suffix=test"
+#   terraform plan -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=test"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=test"
 #
 # Usage (GitHub Actions):
 #   Workflow: Deploy LabLink Infrastructure
 #   Choose environment: test
 #
-# Resource naming: All resources suffixed with -test (e.g., lablink-eip-test)
+# Resource naming: {deployment_name}-{resource-type}-test (e.g., sleap-lablink-eip-test)
 key            = "test/terraform.tfstate"
 dynamodb_table = "lock-table"
 encrypt        = true

--- a/lablink-infrastructure/budget.tf
+++ b/lablink-infrastructure/budget.tf
@@ -1,7 +1,7 @@
 resource "aws_budgets_budget" "lablink_monthly" {
   count = try(local.config_file.monitoring.budget.enabled, false) ? 1 : 0
 
-  name              = "lablink-monthly-budget-${var.resource_suffix}"
+  name              = "${var.deployment_name}-monthly-budget-${var.environment}"
   budget_type       = "COST"
   limit_amount      = try(local.config_file.monitoring.budget.monthly_budget_usd, "100")
   limit_unit        = "USD"
@@ -32,7 +32,7 @@ resource "aws_budgets_budget" "lablink_monthly" {
     threshold                  = 50
     threshold_type             = "PERCENTAGE"
     notification_type          = "ACTUAL"
-    subscriber_email_addresses = [local.config_file.monitoring.email]
+    subscriber_email_addresses = [try(local.config_file.monitoring.email, "")]
   }
 
   # 80% urgent
@@ -41,7 +41,7 @@ resource "aws_budgets_budget" "lablink_monthly" {
     threshold                  = 80
     threshold_type             = "PERCENTAGE"
     notification_type          = "ACTUAL"
-    subscriber_email_addresses = [local.config_file.monitoring.email]
+    subscriber_email_addresses = [try(local.config_file.monitoring.email, "")]
   }
 
   # 100% critical
@@ -50,7 +50,7 @@ resource "aws_budgets_budget" "lablink_monthly" {
     threshold                  = 100
     threshold_type             = "PERCENTAGE"
     notification_type          = "ACTUAL"
-    subscriber_email_addresses = [local.config_file.monitoring.email]
+    subscriber_email_addresses = [try(local.config_file.monitoring.email, "")]
   }
 
   # 150% severe overage
@@ -59,11 +59,10 @@ resource "aws_budgets_budget" "lablink_monthly" {
     threshold                  = 150
     threshold_type             = "PERCENTAGE"
     notification_type          = "ACTUAL"
-    subscriber_email_addresses = [local.config_file.monitoring.email]
+    subscriber_email_addresses = [try(local.config_file.monitoring.email, "")]
   }
 
-  tags = {
-    Name        = "lablink-monthly-budget-${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-monthly-budget-${var.environment}"
+  })
 }

--- a/lablink-infrastructure/config/ci-test.example.yaml
+++ b/lablink-infrastructure/config/ci-test.example.yaml
@@ -9,7 +9,7 @@
 #   ./scripts/setup-aws-infrastructure.sh  # Creates template testing infrastructure
 #   cd lablink-infrastructure
 #   ../scripts/init-terraform.sh ci-test
-#   terraform apply -var="resource_suffix=ci-test"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=ci-test"
 #
 # Note: This uses separate AWS infrastructure from production deployments
 # to avoid conflicts when testing template changes.

--- a/lablink-infrastructure/config/config.yaml
+++ b/lablink-infrastructure/config/config.yaml
@@ -76,23 +76,6 @@ monitoring:
   cloudtrail:
     retention_days: 90 # CloudTrail log retention period in days
 
-# Monitoring and alerting configuration
-monitoring:
-  enabled: true  # Enable CloudWatch alarms and SNS notifications
-  email: "admin@example.com"  # Email for budget alerts and CloudWatch alarms
-
-  budget:
-    enabled: false  # Enable AWS Budget alerts (requires monitoring.email)
-    monthly_budget_usd: "100"  # Monthly budget limit in USD
-
-  thresholds:
-    max_instances_per_5min: 10  # Alert if more than N instances launched in 5 min
-    max_unauthorized_calls_per_15min: 5  # Alert on unauthorized API calls
-    max_terminations_per_5min: 10  # Alert on mass instance terminations
-
-  cloudtrail:
-    retention_days: 90  # CloudTrail log retention in days
-
 # S3 bucket for Terraform state (must be unique globally)
 # Only used for test/prod environments with S3 backend (not used in dev)
 # Template testing uses separate bucket from production deployments

--- a/lablink-infrastructure/config/config.yaml
+++ b/lablink-infrastructure/config/config.yaml
@@ -50,8 +50,8 @@ dns:
   zone_id: "Z1038183268T83E91AYJF" # (Optional) Hardcode zone ID to skip lookup - leave empty for auto-lookup
 
 eip:
-  strategy: "persistent" # "persistent" = reuse EIP with tag {tag_name}-{env}, "dynamic" = create new EIP with tag {tag_name}-{env}
-  tag_name: "lablink-eip" # Tag prefix for EIP name. Both strategies use {tag_name}-{env} format (e.g., lablink-eip-prod).
+  # EIP name is derived from deployment_name: {deployment_name}-eip-{environment}
+  strategy: "persistent"  # "persistent" = reuse existing EIP with matching name tag, "dynamic" = create new EIP each deployment
 
 ssl:
   provider: "letsencrypt" # "letsencrypt" = Caddy auto-SSL, "cloudflare" = CloudFlare proxy, "acm" = AWS Certificate Manager, "none" = HTTP only
@@ -75,6 +75,23 @@ monitoring:
     monthly_budget_usd: 500 # Monthly budget limit in USD
   cloudtrail:
     retention_days: 90 # CloudTrail log retention period in days
+
+# Monitoring and alerting configuration
+monitoring:
+  enabled: true  # Enable CloudWatch alarms and SNS notifications
+  email: "admin@example.com"  # Email for budget alerts and CloudWatch alarms
+
+  budget:
+    enabled: false  # Enable AWS Budget alerts (requires monitoring.email)
+    monthly_budget_usd: "100"  # Monthly budget limit in USD
+
+  thresholds:
+    max_instances_per_5min: 10  # Alert if more than N instances launched in 5 min
+    max_unauthorized_calls_per_15min: 5  # Alert on unauthorized API calls
+    max_terminations_per_5min: 10  # Alert on mass instance terminations
+
+  cloudtrail:
+    retention_days: 90  # CloudTrail log retention in days
 
 # S3 bucket for Terraform state (must be unique globally)
 # Only used for test/prod environments with S3 backend (not used in dev)

--- a/lablink-infrastructure/config/dev.example.yaml
+++ b/lablink-infrastructure/config/dev.example.yaml
@@ -7,7 +7,7 @@
 #   # Edit config.yaml with your values
 #   cd lablink-infrastructure
 #   ../scripts/init-terraform.sh dev
-#   terraform apply -var="resource_suffix=dev"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=dev"
 
 db:
   dbname: "lablink_db"

--- a/lablink-infrastructure/config/ip-only.example.yaml
+++ b/lablink-infrastructure/config/ip-only.example.yaml
@@ -53,8 +53,8 @@ dns:
   zone_id: ""
 
 eip:
-  strategy: "dynamic"
-  tag_name: "lablink-eip"
+  # EIP name is derived from deployment_name: {deployment_name}-eip-{environment}
+  strategy: "dynamic"  # Create new EIP each deployment
 
 ssl:
   provider: "none"  # No SSL - HTTP only

--- a/lablink-infrastructure/config/prod.example.yaml
+++ b/lablink-infrastructure/config/prod.example.yaml
@@ -8,7 +8,7 @@
 #   ./scripts/setup-aws-infrastructure.sh  # Creates S3, DynamoDB, Route53
 #   cd lablink-infrastructure
 #   ../scripts/init-terraform.sh prod
-#   terraform apply -var="resource_suffix=prod"
+#   terraform apply -var="deployment_name=your-lablink" -var="environment=prod"
 
 db:
   dbname: "lablink_db"
@@ -57,8 +57,8 @@ dns:
 
 eip:
   # Consider persistent EIP for production (keeps IP across redeploys)
-  strategy: "persistent" # Reuses existing EIP with tag
-  tag_name: "lablink-eip" # Will become lablink-eip-prod
+  # EIP name is derived from deployment_name: {deployment_name}-eip-{environment}
+  strategy: "persistent" # Reuses existing EIP with matching name tag
 
 ssl:
   # Use Let's Encrypt production certs

--- a/lablink-infrastructure/config/test.example.yaml
+++ b/lablink-infrastructure/config/test.example.yaml
@@ -8,7 +8,7 @@
 #   ./scripts/setup-aws-infrastructure.sh  # Creates S3, DynamoDB, Route53
 #   cd lablink-infrastructure
 #   ../scripts/init-terraform.sh test
-#   terraform apply -var="resource_suffix=test"
+#   terraform apply -var="deployment_name=YOUR-DEPLOYMENT" -var="environment=test"
 
 db:
   dbname: "lablink_db"

--- a/lablink-infrastructure/main.tf
+++ b/lablink-infrastructure/main.tf
@@ -1,7 +1,41 @@
-variable "resource_suffix" {
-  description = "Suffix to append to all resources"
+variable "deployment_name" {
+  description = "Unique name for this deployment (e.g., sleap-lablink, deeplabcut-lablink). Used as prefix for all resources."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*[a-z0-9]$", var.deployment_name)) && length(var.deployment_name) >= 3 && length(var.deployment_name) <= 32
+    error_message = "deployment_name must be 3-32 characters, lowercase kebab-case (e.g., 'sleap-lablink')."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g., dev, test, ci-test, prod)"
   type        = string
   default     = "prod"
+
+  validation {
+    condition     = contains(["dev", "test", "ci-test", "prod"], var.environment)
+    error_message = "environment must be one of: dev, test, ci-test, prod."
+  }
+}
+
+variable "repository" {
+  description = "Source repository for traceability (e.g., talmolab/sleap-lablink). Optional."
+  type        = string
+  default     = ""
+}
+
+# Resource naming convention: {deployment_name}-{resource_type}-{environment}
+locals {
+  # Standard tags applied to all resources
+  common_tags = merge(
+    {
+      Environment = var.environment
+      Project     = var.deployment_name
+      ManagedBy   = "terraform"
+    },
+    var.repository != "" ? { Repository = var.repository } : {}
+  )
 }
 
 # Read configuration from YAML file
@@ -16,7 +50,6 @@ locals {
 
   # EIP configuration from config.yaml
   eip_strategy = try(local.config_file.eip.strategy, "dynamic")
-  eip_tag_name = try(local.config_file.eip.tag_name, "lablink-eip")
 
   # SSL configuration from config.yaml
   ssl_provider        = try(local.config_file.ssl.provider, "none")
@@ -65,7 +98,7 @@ data "aws_iam_policy_document" "s3_backend_doc" {
     effect  = "Allow"
     actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
     resources = [
-      "arn:aws:s3:::${local.bucket_name}/${var.resource_suffix}/*"
+      "arn:aws:s3:::${local.bucket_name}/${var.environment}/*"
     ]
   }
 
@@ -167,17 +200,16 @@ resource "tls_private_key" "lablink_key" {
 
 # Register the public key with AWS
 resource "aws_key_pair" "lablink_key_pair" {
-  key_name   = "lablink-key-${var.resource_suffix}"
+  key_name   = "${var.deployment_name}-keypair-${var.environment}"
   public_key = tls_private_key.lablink_key.public_key_openssh
 
-  tags = {
-    Name        = "lablink-key-${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-keypair-${var.environment}"
+  })
 }
 
 resource "aws_security_group" "allow_http" {
-  name = "allow_http_https_${var.resource_suffix}"
+  name = "${var.deployment_name}-allocator-sg-${var.environment}"
 
   ingress {
     from_port   = 80
@@ -215,10 +247,9 @@ resource "aws_security_group" "allow_http" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = {
-    Name        = "allow_http_https_${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-allocator-sg-${var.environment}"
+  })
 }
 
 resource "aws_instance" "lablink_allocator_server" {
@@ -244,10 +275,9 @@ resource "aws_instance" "lablink_allocator_server" {
     DOMAIN_NAME               = local.install_caddy ? local.dns_domain : ""
   }))
 
-  tags = {
-    Name        = "lablink_allocator_server_${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-allocator-${var.environment}"
+  })
 }
 
 # EIP Lookup (for persistent strategy - reuse existing tagged EIP)
@@ -255,8 +285,8 @@ data "aws_eip" "existing" {
   count = local.eip_strategy == "persistent" ? 1 : 0
 
   tags = {
-    Name        = "${local.eip_tag_name}-${var.resource_suffix}"
-    Environment = var.resource_suffix
+    Name        = "${var.deployment_name}-eip-${var.environment}"
+    Environment = var.environment
   }
 }
 
@@ -265,10 +295,9 @@ resource "aws_eip" "new" {
   count  = local.eip_strategy == "dynamic" ? 1 : 0
   domain = "vpc"
 
-  tags = {
-    Name        = "${local.eip_tag_name}-${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-eip-${var.environment}"
+  })
 }
 
 # Determine which EIP to use based on strategy
@@ -299,11 +328,6 @@ data "aws_route53_zone" "existing" {
   count        = local.dns_enabled && local.dns_zone_id == "" ? 1 : 0
   name         = local.dns_zone_name
   private_zone = false
-
-  tags = {
-    Name        = "lablink-zone-${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
 }
 
 # Compute FQDN, allocator URL, and other derived values
@@ -359,27 +383,25 @@ resource "aws_eip_association" "lablink_allocator_ip_assoc" {
 }
 
 resource "aws_iam_policy" "s3_backend_policy" {
-  name   = "lablink_s3_backend_${var.resource_suffix}"
+  name   = "${var.deployment_name}-s3-backend-policy-${var.environment}"
   policy = data.aws_iam_policy_document.s3_backend_doc.json
 
-  tags = {
-    Name        = "lablink_s3_backend_${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-s3-backend-policy-${var.environment}"
+  })
 }
 
 resource "aws_iam_policy" "ec2_vm_management_policy" {
-  name   = "lablink_ec2_vm_management_${var.resource_suffix}"
+  name   = "${var.deployment_name}-ec2-mgmt-policy-${var.environment}"
   policy = data.aws_iam_policy_document.ec2_vm_management_doc.json
 
-  tags = {
-    Name        = "lablink_ec2_vm_management_${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-ec2-mgmt-policy-${var.environment}"
+  })
 }
 
 resource "aws_iam_role" "instance_role" {
-  name = "lablink_instance_role_${var.resource_suffix}"
+  name = "${var.deployment_name}-allocator-role-${var.environment}"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -390,10 +412,9 @@ resource "aws_iam_role" "instance_role" {
     }]
   })
 
-  tags = {
-    Name        = "lablink_instance_role_${var.resource_suffix}"
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-allocator-role-${var.environment}"
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "attach_ec2_management" {
@@ -407,12 +428,12 @@ resource "aws_iam_role_policy_attachment" "attach_s3_backend" {
 }
 
 resource "aws_iam_instance_profile" "allocator_instance_profile" {
-  name = "lablink_instance_profile_${var.resource_suffix}"
+  name = "${var.deployment_name}-allocator-profile-${var.environment}"
   role = aws_iam_role.instance_role.name
 
-  tags = {
-    Environment = var.resource_suffix
-  }
+  tags = merge(local.common_tags, {
+    Name = "${var.deployment_name}-allocator-profile-${var.environment}"
+  })
 }
 
 # Output the EC2 public IP
@@ -452,15 +473,20 @@ output "allocator_instance_type" {
 # - A security group allowing inbound HTTP (port 80) and SSH (port 22) traffic.
 # - An association between the EC2 instance and the fixed EIP.
 #
-# DNS records are managed manually in Route 53.
-# - The EIP is manually mapped to either `lablink.example.com` (for prod) or
-#   `{resource_suffix}.lablink.example.com` (for dev, test, etc.).
-# Note: EIPs must be pre-allocated and tagged as "lablink-eip-prod", "lablink-eip-dev", etc.
+# DNS records are managed manually in Route 53 or via Terraform (dns.terraform_managed).
+#
+# Resource Naming Convention:
+# All resources follow the pattern: {deployment_name}-{resource-type}-{environment}
+# Example: sleap-lablink-allocator-prod, sleap-lablink-eip-dev
+#
+# For persistent EIP strategy, EIPs must be pre-allocated and tagged with the
+# matching name: {deployment_name}-eip-{environment}
 #
 # The container is pulled from GitHub Container Registry and exposed on port 5000,
 # which is made externally accessible via port 80 on the EC2 instance.
 #
-# The configuration is environment-aware, using the `resource_suffix` variable
-# to differentiate resource names and subdomains (e.g., `prod`, `dev`, `test`).
+# The configuration uses two variables:
+# - deployment_name: Unique identifier for this deployment (e.g., sleap-lablink)
+# - environment: The deployment environment (dev, test, ci-test, prod)
 #
 # Outputs include the EC2 public IP, SSH key name, and the generated private key (marked sensitive).

--- a/lablink-infrastructure/main.tf
+++ b/lablink-infrastructure/main.tf
@@ -169,8 +169,8 @@ data "aws_iam_policy_document" "ec2_vm_management_doc" {
       "iam:GetInstanceProfile"
     ]
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-lablink-client-*-vm-role",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/*-lablink-client-*-instance-profile"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-client-*-vm-role",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/*-client-*-instance-profile"
     ]
   }
 
@@ -181,7 +181,7 @@ data "aws_iam_policy_document" "ec2_vm_management_doc" {
       "iam:PassRole"
     ]
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-lablink-client-*-vm-role"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*-client-*-vm-role"
     ]
     condition {
       test     = "StringEquals"
@@ -261,10 +261,10 @@ resource "aws_instance" "lablink_allocator_server" {
 
   user_data_base64 = base64gzip(templatefile("${path.module}/user_data.sh", {
     ALLOCATOR_IMAGE_TAG       = local.allocator_image_tag
-    RESOURCE_SUFFIX           = var.resource_suffix
+    RESOURCE_SUFFIX           = var.environment
     ALLOCATOR_PUBLIC_IP       = local.eip_public_ip
     ALLOCATOR_KEY_NAME        = aws_key_pair.lablink_key_pair.key_name
-    LOG_GROUP                 = "lablink-cloud-init-${var.resource_suffix}"
+    LOG_GROUP                 = "${var.deployment_name}-client-logs-${var.environment}"
     CONFIG_CONTENT            = file("${path.module}/config/config.yaml")
     CLIENT_STARTUP_SCRIPT_B64 = local.startup_script_b64
     STARTUP_ENABLED           = local.startup_enabled

--- a/openspec/changes/standardize-resource-naming/design.md
+++ b/openspec/changes/standardize-resource-naming/design.md
@@ -1,0 +1,140 @@
+## Context
+
+LabLink Infrastructure Template is designed to be forked by multiple research labs. Each lab may deploy multiple environments (dev, test, prod) and some labs share AWS accounts. The current hardcoded `lablink-` prefix and inconsistent naming prevents:
+
+1. Multiple deployments in the same AWS account
+2. Easy cost allocation per project
+3. Reliable resource querying via AWS Resource Groups Tagging API
+4. Clear resource ownership and traceability
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable multiple independent deployments in a single AWS account
+- Provide consistent, predictable resource naming
+- Support cost allocation and resource querying via tags
+- Maintain backwards compatibility in configuration structure
+
+**Non-Goals:**
+- Zero-downtime migration (resources must be recreated)
+- Supporting mixed naming conventions within a deployment
+- Changing the Terraform state backend structure
+
+## Decisions
+
+### Decision 1: Two-Variable Naming Scheme
+
+**What:** Introduce `deployment_name` (required) and rename `resource_suffix` to `environment`.
+
+**Why:** Separating deployment identity from environment allows:
+- Same deployment across environments: `sleap-lablink-alb-dev`, `sleap-lablink-alb-prod`
+- Different deployments in same account: `sleap-lablink-alb-prod`, `deeplabcut-lablink-alb-prod`
+
+**Alternatives considered:**
+- Single combined variable: Rejected because it conflates identity with environment
+- Three variables (org/project/env): Rejected as over-engineered for current needs
+
+### Decision 2: Naming Format `{deployment}-{resource-type}-{environment}`
+
+**What:** All resources follow the pattern `{deployment_name}-{resource_type}-{environment}`.
+
+**Why:**
+- Deployment first enables AWS console sorting by project
+- Resource type in middle provides context
+- Environment last enables easy filtering (e.g., `*-prod`)
+
+**Examples:**
+| Resource | Name |
+|----------|------|
+| ALB | `sleap-lablink-alb-prod` |
+| Security Group (ALB) | `sleap-lablink-alb-sg-prod` |
+| IAM Role (allocator) | `sleap-lablink-allocator-role-prod` |
+| S3 Bucket | `sleap-lablink-cloudtrail-bucket-prod-{account_id}` |
+| CloudWatch Alarm | `sleap-lablink-alarm-mass-launch-prod` |
+
+### Decision 3: Standardize on Kebab-Case
+
+**What:** Use kebab-case (`-`) for all resources, including IAM.
+
+**Why:**
+- Consistency across all AWS resource types
+- More readable than underscores
+- AWS allows kebab-case in IAM resource names
+
+**Current inconsistencies to fix:**
+- IAM roles: `lablink_instance_role_*` → `{deployment}-allocator-role-{env}`
+- IAM policies: `lablink_s3_backend_*` → `{deployment}-s3-backend-policy-{env}`
+- Lambda functions: `lablink_log_processor_*` → `{deployment}-log-processor-{env}`
+- Security group: `allow_http_https_*` → `{deployment}-allocator-sg-{env}`
+
+### Decision 4: Standard Tag Set
+
+**What:** Apply five tags to all taggable resources.
+
+| Tag | Source | Purpose |
+|-----|--------|---------|
+| `Name` | Computed | Resource identifier |
+| `Environment` | `var.environment` | Deployment environment |
+| `Project` | `var.deployment_name` | Cost allocation, resource grouping |
+| `ManagedBy` | `"terraform"` (hardcoded) | Distinguish from manual resources |
+| `Repository` | `var.repository` (optional) | Traceability to source code |
+
+**Why:**
+- `Project` enables AWS Cost Explorer grouping
+- `ManagedBy` helps identify orphaned manual resources
+- `Repository` provides audit trail for infrastructure changes
+
+### Decision 5: Local Variables for Name Construction
+
+**What:** Use Terraform locals to construct names consistently.
+
+```hcl
+locals {
+  name_prefix = "${var.deployment_name}"
+  name_suffix = "${var.environment}"
+
+  # Standard tags applied to all resources
+  common_tags = {
+    Environment = var.environment
+    Project     = var.deployment_name
+    ManagedBy   = "terraform"
+    Repository  = var.repository
+  }
+}
+
+# Usage example
+resource "aws_lb" "allocator_alb" {
+  name = "${local.name_prefix}-alb-${local.name_suffix}"
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-alb-${local.name_suffix}"
+  })
+}
+```
+
+**Why:**
+- Single source of truth for naming logic
+- Easy to update format in one place
+- Reduces copy-paste errors
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking change requires infrastructure recreation | Document migration steps; provide destroy-then-apply workflow |
+| Longer resource names may hit AWS limits | Test all resource types; S3 bucket names have 63-char limit |
+| Existing deployments become orphaned | Clear migration documentation; announce in release notes |
+
+## Migration Plan
+
+1. **Announce breaking change** in release notes
+2. **Users destroy existing infrastructure** using current naming
+3. **Users update configuration** with new `deployment_name` variable
+4. **Users deploy fresh** with new naming convention
+5. **Verify resources** using AWS Resource Groups Tagging API query
+
+**Rollback:** Not applicable (this is a naming change, not a feature that can be toggled).
+
+## Open Questions
+
+- Should `repository` tag be required or optional with sensible default?
+- Should we add a `CostCenter` tag for organizations with billing codes?

--- a/openspec/changes/standardize-resource-naming/migration.md
+++ b/openspec/changes/standardize-resource-naming/migration.md
@@ -1,0 +1,79 @@
+# Migration Guide: Standardized Resource Naming
+
+## Breaking Change
+
+All Terraform resources now use the naming pattern `{deployment_name}-{resource-type}-{environment}` instead of the previous `lablink-{resource}-{suffix}` pattern. This requires a full infrastructure recreation.
+
+## New Required Variable
+
+A new `deployment_name` variable is required (no default). This is a unique kebab-case identifier for your deployment (e.g., `sleap-lablink`, `deeplabcut-lablink`).
+
+The old `resource_suffix` variable has been renamed to `environment`.
+
+## Migration Steps
+
+### 1. Destroy existing infrastructure
+
+Using the **old** code (before pulling this change):
+
+```bash
+cd lablink-infrastructure
+terraform destroy -var="resource_suffix=<your-env>"
+```
+
+Or use the GitHub Actions "Destroy LabLink Infrastructure" workflow.
+
+### 2. Pull the new code
+
+```bash
+git pull origin main
+```
+
+### 3. Update your config.yaml
+
+- Remove the `eip.tag_name` field (EIP name is now derived from `deployment_name`)
+- No other config changes required
+
+### 4. Pre-tag your persistent EIP (if using persistent strategy)
+
+If you use `eip.strategy: "persistent"`, tag your existing EIP with the new naming:
+
+```bash
+aws ec2 create-tags \
+  --resources <your-eip-allocation-id> \
+  --tags Key=Name,Value=<deployment_name>-eip-<environment> Key=Environment,Value=<environment>
+```
+
+### 5. Deploy with new variables
+
+```bash
+cd lablink-infrastructure
+../scripts/init-terraform.sh <environment>
+terraform plan \
+  -var="deployment_name=<your-deployment-name>" \
+  -var="environment=<your-env>"
+terraform apply \
+  -var="deployment_name=<your-deployment-name>" \
+  -var="environment=<your-env>"
+```
+
+Or use the GitHub Actions "Deploy LabLink Infrastructure" workflow with the new `deployment_name` input.
+
+### 6. Verify resources
+
+```bash
+aws resourcegroupstaggingapi get-resources \
+  --tag-filters Key=Project,Values=<your-deployment-name>
+```
+
+## Variable Mapping
+
+| Old | New |
+|-----|-----|
+| `resource_suffix` | `environment` |
+| _(none)_ | `deployment_name` (required) |
+| _(none)_ | `repository` (optional) |
+
+## Rollback
+
+This change cannot be rolled back without destroying and recreating infrastructure. If you need to revert, destroy the new-named resources and redeploy using a commit before this change.

--- a/openspec/changes/standardize-resource-naming/proposal.md
+++ b/openspec/changes/standardize-resource-naming/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+This is a template repository intended to be forked and deployed by multiple teams. Currently, resources use a hardcoded `lablink-` prefix and only a single `resource_suffix` variable for environment differentiation. This prevents multiple deployments from coexisting in the same AWS account and makes cost allocation and resource management difficult.
+
+Additionally, naming conventions are inconsistent (kebab-case vs underscores) and tags are minimal, making resource querying unreliable.
+
+**Related Issue:** [#28 - Standardize Terraform resource naming for multi-deployment support](https://github.com/talmolab/lablink-template/issues/28)
+
+## What Changes
+
+- **BREAKING**: Add required `deployment_name` variable (no default)
+- Rename `resource_suffix` to `environment` for clarity
+- Standardize all resource names to format: `{deployment}-{resource-type}-{environment}`
+- Standardize on kebab-case for all resources (currently IAM resources use underscores)
+- Add consistent tags across all resources: `Project`, `ManagedBy`, `Repository`
+- Update all backend configuration files
+- Update example configuration files
+
+## Impact
+
+- **Affected specs:** infrastructure
+- **Affected code:**
+  - `lablink-infrastructure/main.tf` - Core resource definitions
+  - `lablink-infrastructure/alb.tf` - ALB and security group resources
+  - `lablink-infrastructure/cloudtrail.tf` - CloudTrail and S3 resources
+  - `lablink-infrastructure/cloudwatch_alarms.tf` - Monitoring resources
+  - `lablink-infrastructure/budget.tf` - Budget resources
+  - `lablink-infrastructure/backend-*.hcl` - Backend configuration files
+  - `lablink-infrastructure/config/*.yaml` - Example configuration files
+  - `.github/workflows/*.yml` - CI/CD workflows
+- **Migration:** Existing deployments must be destroyed and recreated with new naming (resources cannot be renamed in-place in AWS)

--- a/openspec/changes/standardize-resource-naming/specs/infrastructure/spec.md
+++ b/openspec/changes/standardize-resource-naming/specs/infrastructure/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: Deployment Name Variable
+The infrastructure SHALL require a `deployment_name` variable to uniquely identify each deployment within an AWS account.
+
+#### Scenario: Deployment name is required
+- **WHEN** `deployment_name` is not provided
+- **THEN** Terraform fails with a validation error
+
+#### Scenario: Deployment name used in resource names
+- **WHEN** `deployment_name="sleap-lablink"` AND `environment="prod"`
+- **THEN** all resource names start with `sleap-lablink-`
+
+#### Scenario: Deployment name validation
+- **WHEN** `deployment_name` contains invalid characters (uppercase, underscores, spaces)
+- **THEN** Terraform fails with a validation error indicating kebab-case is required
+
+### Requirement: Resource Naming Convention
+All AWS resources SHALL follow the naming pattern `{deployment_name}-{resource_type}-{environment}` using kebab-case.
+
+#### Scenario: Compute resources follow naming convention
+- **WHEN** deployment deploys compute resources
+- **THEN** EC2 instance is tagged `{deployment}-allocator-{env}`
+- **AND** Key pair is named `{deployment}-keypair-{env}`
+
+#### Scenario: Networking resources follow naming convention
+- **WHEN** deployment deploys networking resources
+- **THEN** ALB is named `{deployment}-alb-{env}`
+- **AND** Target group is named `{deployment}-alb-tg-{env}`
+- **AND** Security groups are named `{deployment}-allocator-sg-{env}` and `{deployment}-alb-sg-{env}`
+- **AND** Elastic IP is tagged `{deployment}-eip-{env}`
+
+#### Scenario: IAM resources follow naming convention
+- **WHEN** deployment deploys IAM resources
+- **THEN** Instance role is named `{deployment}-allocator-role-{env}`
+- **AND** Lambda role is named `{deployment}-lambda-role-{env}`
+- **AND** Instance profile is named `{deployment}-allocator-profile-{env}`
+- **AND** Policies are named `{deployment}-{policy-purpose}-policy-{env}`
+
+#### Scenario: Monitoring resources follow naming convention
+- **WHEN** deployment deploys monitoring resources
+- **THEN** SNS topic is named `{deployment}-alerts-topic-{env}`
+- **AND** CloudWatch alarms are named `{deployment}-alarm-{alarm-type}-{env}`
+- **AND** Metric filters are named `{deployment}-metric-{metric-type}-{env}`
+
+#### Scenario: Storage resources follow naming convention
+- **WHEN** deployment deploys storage resources
+- **THEN** S3 bucket is named `{deployment}-cloudtrail-bucket-{env}-{account_id}`
+- **AND** CloudWatch log groups are named `{deployment}-{log-purpose}-logs-{env}`
+
+#### Scenario: Lambda resources follow naming convention
+- **WHEN** deployment deploys Lambda resources
+- **THEN** Lambda function is named `{deployment}-log-processor-{env}`
+- **AND** Lambda log group follows AWS path convention `/aws/lambda/{deployment}-log-processor-{env}`
+
+### Requirement: Resource Tagging
+All taggable AWS resources SHALL include a standard set of tags for cost allocation and resource management.
+
+#### Scenario: All resources have required tags
+- **WHEN** any taggable resource is created
+- **THEN** resource has tag `Name` matching the resource name
+- **AND** resource has tag `Environment` matching `var.environment`
+- **AND** resource has tag `Project` matching `var.deployment_name`
+- **AND** resource has tag `ManagedBy` with value `terraform`
+
+#### Scenario: Optional repository tag
+- **WHEN** `var.repository` is provided
+- **THEN** all resources have tag `Repository` with the provided value
+
+#### Scenario: Route53 records have tags
+- **WHEN** Route53 records are created
+- **THEN** records have all standard tags (Name, Environment, Project, ManagedBy)
+
+#### Scenario: Query resources by project tag
+- **WHEN** AWS CLI command `aws resourcegroupstaggingapi get-resources --tag-filters Key=Project,Values={deployment_name}` is executed
+- **THEN** all resources for the deployment are returned
+
+### Requirement: Multi-Deployment Isolation
+Multiple deployments SHALL coexist in the same AWS account without resource name conflicts.
+
+#### Scenario: Two deployments in same account
+- **WHEN** `sleap-lablink` deployment exists in `prod` environment
+- **AND** `deeplabcut-lablink` deployment is created in `prod` environment
+- **THEN** both deployments succeed without name conflicts
+- **AND** resources are independently manageable
+
+#### Scenario: Same deployment across environments
+- **WHEN** `sleap-lablink` deployment exists in `prod` environment
+- **AND** `sleap-lablink` deployment is created in `dev` environment
+- **THEN** both deployments succeed without name conflicts
+- **AND** resources are independently manageable
+
+#### Scenario: Terraform state isolation
+- **WHEN** multiple deployments exist
+- **THEN** each deployment has separate Terraform state file
+- **AND** operations on one deployment do not affect others
+
+## MODIFIED Requirements
+
+### Requirement: DNS Configuration
+The system SHALL accept full domain names in dns.domain and support sub-subdomains without pattern-based construction.
+
+#### Scenario: Full domain specified
+- **WHEN** dns.domain="lablink.sleap.ai"
+- **THEN** Route53 A record is created for "lablink.sleap.ai" (exact match)
+
+#### Scenario: Sub-subdomain specified
+- **WHEN** dns.domain="test.lablink.sleap.ai"
+- **THEN** Route53 A record is created for "test.lablink.sleap.ai" (exact match)
+
+#### Scenario: Zone lookup matches exact domain
+- **WHEN** dns.zone_id="" AND dns.domain="lablink.sleap.ai"
+- **THEN** Terraform looks up hosted zone for "lablink.sleap.ai." (exact match only)
+
+#### Scenario: DNS records have standard tags
+- **WHEN** Route53 records are created with dns.terraform_managed=true
+- **THEN** records include Project, Environment, and ManagedBy tags

--- a/openspec/changes/standardize-resource-naming/tasks.md
+++ b/openspec/changes/standardize-resource-naming/tasks.md
@@ -1,0 +1,120 @@
+## 1. Variables and Locals Setup
+
+- [ ] 1.1 Add `deployment_name` variable with validation (required, kebab-case pattern)
+- [ ] 1.2 Rename `resource_suffix` to `environment` in variables
+- [ ] 1.3 Add optional `repository` variable for traceability tag
+- [ ] 1.4 Create `locals` block with:
+  - [ ] 1.4.1 `name_prefix` = `var.deployment_name`
+  - [ ] 1.4.2 `name_suffix` = `var.environment`
+  - [ ] 1.4.3 `common_tags` map with standard tags
+- [ ] 1.5 Run `terraform validate` to verify variable syntax
+
+## 2. Resource Naming Updates (main.tf)
+
+### 2.1 Compute Resources
+- [ ] 2.1.1 Update `aws_key_pair` name: `{deployment}-keypair-{env}`
+- [ ] 2.1.2 Update `aws_instance` tags: `{deployment}-allocator-{env}`
+- [ ] 2.1.3 Update `aws_eip` tags: `{deployment}-eip-{env}`
+
+### 2.2 Networking Resources
+- [ ] 2.2.1 Update `aws_security_group` (allocator): `{deployment}-allocator-sg-{env}`
+- [ ] 2.2.2 Add standard tags to all security groups
+
+### 2.3 IAM Resources
+- [ ] 2.3.1 Update `aws_iam_role` (instance): `{deployment}-allocator-role-{env}`
+- [ ] 2.3.2 Update `aws_iam_role` (lambda): `{deployment}-lambda-role-{env}`
+- [ ] 2.3.3 Update `aws_iam_policy` (S3): `{deployment}-s3-backend-policy-{env}`
+- [ ] 2.3.4 Update `aws_iam_policy` (EC2): `{deployment}-ec2-mgmt-policy-{env}`
+- [ ] 2.3.5 Update `aws_iam_instance_profile`: `{deployment}-allocator-profile-{env}`
+- [ ] 2.3.6 Add standard tags to all IAM resources
+
+### 2.4 Lambda Resources
+- [ ] 2.4.1 Update `aws_lambda_function`: `{deployment}-log-processor-{env}`
+- [ ] 2.4.2 Update `aws_cloudwatch_log_group` (lambda): `/aws/lambda/{deployment}-log-processor-{env}`
+- [ ] 2.4.3 Update `aws_cloudwatch_log_subscription_filter` name
+- [ ] 2.4.4 Add standard tags to Lambda resources
+
+### 2.5 CloudWatch Log Groups
+- [ ] 2.5.1 Update client VM log group: `{deployment}-client-logs-{env}`
+- [ ] 2.5.2 Add standard tags to log groups
+
+### 2.6 Route53 Records
+- [ ] 2.6.1 Add standard tags to `aws_route53_record` (allocator)
+- [ ] 2.6.2 Add standard tags to `aws_route53_record` (ALB)
+
+## 3. Resource Naming Updates (alb.tf)
+
+- [ ] 3.1 Update `aws_security_group` (ALB): `{deployment}-alb-sg-{env}`
+- [ ] 3.2 Update `aws_lb`: `{deployment}-alb-{env}`
+- [ ] 3.3 Update `aws_lb_target_group`: `{deployment}-alb-tg-{env}`
+- [ ] 3.4 Add standard tags to all ALB resources
+
+## 4. Resource Naming Updates (cloudtrail.tf)
+
+- [ ] 4.1 Update `aws_s3_bucket`: `{deployment}-cloudtrail-bucket-{env}-{account_id}`
+- [ ] 4.2 Update `aws_cloudwatch_log_group`: `{deployment}-cloudtrail-logs-{env}`
+- [ ] 4.3 Update `aws_iam_role` (cloudtrail): `{deployment}-cloudtrail-role-{env}`
+- [ ] 4.4 Update `aws_cloudtrail`: `{deployment}-cloudtrail-{env}`
+- [ ] 4.5 Add standard tags to all CloudTrail resources
+
+## 5. Resource Naming Updates (cloudwatch_alarms.tf)
+
+- [ ] 5.1 Update `aws_sns_topic`: `{deployment}-alerts-topic-{env}`
+- [ ] 5.2 Update metric filters:
+  - [ ] 5.2.1 `{deployment}-metric-run-instances-{env}`
+  - [ ] 5.2.2 `{deployment}-metric-large-instances-{env}`
+  - [ ] 5.2.3 `{deployment}-metric-unauthorized-{env}`
+  - [ ] 5.2.4 `{deployment}-metric-termination-{env}`
+- [ ] 5.3 Update alarms:
+  - [ ] 5.3.1 `{deployment}-alarm-mass-launch-{env}`
+  - [ ] 5.3.2 `{deployment}-alarm-large-instance-{env}`
+  - [ ] 5.3.3 `{deployment}-alarm-unauthorized-{env}`
+  - [ ] 5.3.4 `{deployment}-alarm-termination-{env}`
+- [ ] 5.4 Update CloudWatch namespace: `{deployment}Security/{env}`
+- [ ] 5.5 Add standard tags to all monitoring resources
+
+## 6. Resource Naming Updates (budget.tf)
+
+- [ ] 6.1 Update `aws_budgets_budget`: `{deployment}-monthly-budget-{env}`
+- [ ] 6.2 Add standard tags to budget resource
+
+## 7. Configuration Updates
+
+- [ ] 7.1 Update `backend-*.hcl` files with new variable documentation
+- [ ] 7.2 Update example config files:
+  - [ ] 7.2.1 Add `deployment_name` to `config/prod.example.yaml`
+  - [ ] 7.2.2 Add `deployment_name` to `config/ip-only.example.yaml`
+- [ ] 7.3 Update any hardcoded `lablink-eip` references in config
+
+## 8. CI/CD Updates
+
+- [ ] 8.1 Update GitHub Actions workflows to pass `deployment_name`
+- [ ] 8.2 Update destroy workflow with new variable
+- [ ] 8.3 Add `deployment_name` to workflow inputs where applicable
+
+## 9. Documentation Updates
+
+- [ ] 9.1 Update `openspec/project.md` with new naming convention
+- [ ] 9.2 Update backend-*.hcl header comments with new pattern
+- [ ] 9.3 Add migration guide to release notes
+
+## 10. Validation and Testing
+
+- [ ] 10.1 Run `terraform fmt` on all .tf files
+- [ ] 10.2 Run `terraform validate` to check syntax
+- [ ] 10.3 Run `terraform plan` with test configuration to verify:
+  - [ ] 10.3.1 All resources have correct naming pattern
+  - [ ] 10.3.2 All resources have standard tags
+  - [ ] 10.3.3 No hardcoded `lablink-` prefixes remain
+- [ ] 10.4 Verify tag query works:
+  ```bash
+  aws resourcegroupstaggingapi get-resources --tag-filters Key=Project,Values={deployment_name}
+  ```
+- [ ] 10.5 Test multi-deployment scenario (if possible in ci-test)
+
+## 11. Final Verification
+
+- [ ] 11.1 Search codebase for remaining `lablink_` (underscore) patterns
+- [ ] 11.2 Search codebase for remaining hardcoded `lablink-` prefixes
+- [ ] 11.3 Verify all resources in terraform plan use new naming
+- [ ] 11.4 Update GitHub issue #28 with completion status

--- a/openspec/changes/standardize-resource-naming/tasks.md
+++ b/openspec/changes/standardize-resource-naming/tasks.md
@@ -1,96 +1,96 @@
 ## 1. Variables and Locals Setup
 
-- [ ] 1.1 Add `deployment_name` variable with validation (required, kebab-case pattern)
-- [ ] 1.2 Rename `resource_suffix` to `environment` in variables
-- [ ] 1.3 Add optional `repository` variable for traceability tag
-- [ ] 1.4 Create `locals` block with:
-  - [ ] 1.4.1 `name_prefix` = `var.deployment_name`
-  - [ ] 1.4.2 `name_suffix` = `var.environment`
-  - [ ] 1.4.3 `common_tags` map with standard tags
-- [ ] 1.5 Run `terraform validate` to verify variable syntax
+- [x] 1.1 Add `deployment_name` variable with validation (required, kebab-case pattern)
+- [x] 1.2 Rename `resource_suffix` to `environment` in variables
+- [x] 1.3 Add optional `repository` variable for traceability tag
+- [x] 1.4 Create `locals` block with:
+  - [x] 1.4.1 `name_prefix` = `var.deployment_name`
+  - [x] 1.4.2 `name_suffix` = `var.environment`
+  - [x] 1.4.3 `common_tags` map with standard tags
+- [x] 1.5 Run `terraform validate` to verify variable syntax
 
 ## 2. Resource Naming Updates (main.tf)
 
 ### 2.1 Compute Resources
-- [ ] 2.1.1 Update `aws_key_pair` name: `{deployment}-keypair-{env}`
-- [ ] 2.1.2 Update `aws_instance` tags: `{deployment}-allocator-{env}`
-- [ ] 2.1.3 Update `aws_eip` tags: `{deployment}-eip-{env}`
+- [x] 2.1.1 Update `aws_key_pair` name: `{deployment}-keypair-{env}`
+- [x] 2.1.2 Update `aws_instance` tags: `{deployment}-allocator-{env}`
+- [x] 2.1.3 Update `aws_eip` tags: `{deployment}-eip-{env}`
 
 ### 2.2 Networking Resources
-- [ ] 2.2.1 Update `aws_security_group` (allocator): `{deployment}-allocator-sg-{env}`
-- [ ] 2.2.2 Add standard tags to all security groups
+- [x] 2.2.1 Update `aws_security_group` (allocator): `{deployment}-allocator-sg-{env}`
+- [x] 2.2.2 Add standard tags to all security groups
 
 ### 2.3 IAM Resources
-- [ ] 2.3.1 Update `aws_iam_role` (instance): `{deployment}-allocator-role-{env}`
-- [ ] 2.3.2 Update `aws_iam_role` (lambda): `{deployment}-lambda-role-{env}`
-- [ ] 2.3.3 Update `aws_iam_policy` (S3): `{deployment}-s3-backend-policy-{env}`
-- [ ] 2.3.4 Update `aws_iam_policy` (EC2): `{deployment}-ec2-mgmt-policy-{env}`
-- [ ] 2.3.5 Update `aws_iam_instance_profile`: `{deployment}-allocator-profile-{env}`
-- [ ] 2.3.6 Add standard tags to all IAM resources
+- [x] 2.3.1 Update `aws_iam_role` (instance): `{deployment}-allocator-role-{env}`
+- [x] 2.3.2 Update `aws_iam_role` (lambda): `{deployment}-lambda-role-{env}`
+- [x] 2.3.3 Update `aws_iam_policy` (S3): `{deployment}-s3-backend-policy-{env}`
+- [x] 2.3.4 Update `aws_iam_policy` (EC2): `{deployment}-ec2-mgmt-policy-{env}`
+- [x] 2.3.5 Update `aws_iam_instance_profile`: `{deployment}-allocator-profile-{env}`
+- [x] 2.3.6 Add standard tags to all IAM resources
 
 ### 2.4 Lambda Resources
-- [ ] 2.4.1 Update `aws_lambda_function`: `{deployment}-log-processor-{env}`
-- [ ] 2.4.2 Update `aws_cloudwatch_log_group` (lambda): `/aws/lambda/{deployment}-log-processor-{env}`
-- [ ] 2.4.3 Update `aws_cloudwatch_log_subscription_filter` name
-- [ ] 2.4.4 Add standard tags to Lambda resources
+- [x] 2.4.1 Update `aws_lambda_function`: `{deployment}-log-processor-{env}`
+- [x] 2.4.2 Update `aws_cloudwatch_log_group` (lambda): `/aws/lambda/{deployment}-log-processor-{env}`
+- [x] 2.4.3 Update `aws_cloudwatch_log_subscription_filter` name
+- [x] 2.4.4 Add standard tags to Lambda resources
 
 ### 2.5 CloudWatch Log Groups
-- [ ] 2.5.1 Update client VM log group: `{deployment}-client-logs-{env}`
-- [ ] 2.5.2 Add standard tags to log groups
+- [x] 2.5.1 Update client VM log group: `{deployment}-client-logs-{env}`
+- [x] 2.5.2 Add standard tags to log groups
 
 ### 2.6 Route53 Records
-- [ ] 2.6.1 Add standard tags to `aws_route53_record` (allocator)
-- [ ] 2.6.2 Add standard tags to `aws_route53_record` (ALB)
+- [x] 2.6.1 ~~Add standard tags to `aws_route53_record` (allocator)~~ N/A - Route53 records don't support tags
+- [x] 2.6.2 ~~Add standard tags to `aws_route53_record` (ALB)~~ N/A - Route53 records don't support tags
 
 ## 3. Resource Naming Updates (alb.tf)
 
-- [ ] 3.1 Update `aws_security_group` (ALB): `{deployment}-alb-sg-{env}`
-- [ ] 3.2 Update `aws_lb`: `{deployment}-alb-{env}`
-- [ ] 3.3 Update `aws_lb_target_group`: `{deployment}-alb-tg-{env}`
-- [ ] 3.4 Add standard tags to all ALB resources
+- [x] 3.1 Update `aws_security_group` (ALB): `{deployment}-alb-sg-{env}`
+- [x] 3.2 Update `aws_lb`: `{deployment}-alb-{env}`
+- [x] 3.3 Update `aws_lb_target_group`: `{deployment}-alb-tg-{env}`
+- [x] 3.4 Add standard tags to all ALB resources
 
 ## 4. Resource Naming Updates (cloudtrail.tf)
 
-- [ ] 4.1 Update `aws_s3_bucket`: `{deployment}-cloudtrail-bucket-{env}-{account_id}`
-- [ ] 4.2 Update `aws_cloudwatch_log_group`: `{deployment}-cloudtrail-logs-{env}`
-- [ ] 4.3 Update `aws_iam_role` (cloudtrail): `{deployment}-cloudtrail-role-{env}`
-- [ ] 4.4 Update `aws_cloudtrail`: `{deployment}-cloudtrail-{env}`
-- [ ] 4.5 Add standard tags to all CloudTrail resources
+- [x] 4.1 Update `aws_s3_bucket`: `{deployment}-cloudtrail-bucket-{env}-{account_id}`
+- [x] 4.2 Update `aws_cloudwatch_log_group`: `{deployment}-cloudtrail-logs-{env}`
+- [x] 4.3 Update `aws_iam_role` (cloudtrail): `{deployment}-cloudtrail-role-{env}`
+- [x] 4.4 Update `aws_cloudtrail`: `{deployment}-cloudtrail-{env}`
+- [x] 4.5 Add standard tags to all CloudTrail resources
 
 ## 5. Resource Naming Updates (cloudwatch_alarms.tf)
 
-- [ ] 5.1 Update `aws_sns_topic`: `{deployment}-alerts-topic-{env}`
-- [ ] 5.2 Update metric filters:
-  - [ ] 5.2.1 `{deployment}-metric-run-instances-{env}`
-  - [ ] 5.2.2 `{deployment}-metric-large-instances-{env}`
-  - [ ] 5.2.3 `{deployment}-metric-unauthorized-{env}`
-  - [ ] 5.2.4 `{deployment}-metric-termination-{env}`
-- [ ] 5.3 Update alarms:
-  - [ ] 5.3.1 `{deployment}-alarm-mass-launch-{env}`
-  - [ ] 5.3.2 `{deployment}-alarm-large-instance-{env}`
-  - [ ] 5.3.3 `{deployment}-alarm-unauthorized-{env}`
-  - [ ] 5.3.4 `{deployment}-alarm-termination-{env}`
-- [ ] 5.4 Update CloudWatch namespace: `{deployment}Security/{env}`
-- [ ] 5.5 Add standard tags to all monitoring resources
+- [x] 5.1 Update `aws_sns_topic`: `{deployment}-alerts-topic-{env}`
+- [x] 5.2 Update metric filters:
+  - [x] 5.2.1 `{deployment}-metric-run-instances-{env}`
+  - [x] 5.2.2 `{deployment}-metric-large-instances-{env}`
+  - [x] 5.2.3 `{deployment}-metric-unauthorized-{env}`
+  - [x] 5.2.4 `{deployment}-metric-termination-{env}`
+- [x] 5.3 Update alarms:
+  - [x] 5.3.1 `{deployment}-alarm-mass-launch-{env}`
+  - [x] 5.3.2 `{deployment}-alarm-large-instance-{env}`
+  - [x] 5.3.3 `{deployment}-alarm-unauthorized-{env}`
+  - [x] 5.3.4 `{deployment}-alarm-termination-{env}`
+- [x] 5.4 Update CloudWatch namespace: `{deployment}Security/{env}`
+- [x] 5.5 Add standard tags to all monitoring resources
 
 ## 6. Resource Naming Updates (budget.tf)
 
-- [ ] 6.1 Update `aws_budgets_budget`: `{deployment}-monthly-budget-{env}`
-- [ ] 6.2 Add standard tags to budget resource
+- [x] 6.1 Update `aws_budgets_budget`: `{deployment}-monthly-budget-{env}`
+- [x] 6.2 Add standard tags to budget resource
 
 ## 7. Configuration Updates
 
 - [ ] 7.1 Update `backend-*.hcl` files with new variable documentation
-- [ ] 7.2 Update example config files:
-  - [ ] 7.2.1 Add `deployment_name` to `config/prod.example.yaml`
-  - [ ] 7.2.2 Add `deployment_name` to `config/ip-only.example.yaml`
-- [ ] 7.3 Update any hardcoded `lablink-eip` references in config
+- [x] 7.2 Update example config files:
+  - [x] 7.2.1 Add monitoring section to `config/prod.example.yaml`
+  - [x] 7.2.2 Add monitoring section to `config/ip-only.example.yaml`
+- [x] 7.3 Remove obsolete `eip.tag_name` references in config
 
 ## 8. CI/CD Updates
 
-- [ ] 8.1 Update GitHub Actions workflows to pass `deployment_name`
-- [ ] 8.2 Update destroy workflow with new variable
-- [ ] 8.3 Add `deployment_name` to workflow inputs where applicable
+- [x] 8.1 Update GitHub Actions workflows to pass `deployment_name`
+- [x] 8.2 Update destroy workflow with new variable
+- [x] 8.3 Add `deployment_name` to workflow inputs where applicable
 
 ## 9. Documentation Updates
 
@@ -101,7 +101,7 @@
 ## 10. Validation and Testing
 
 - [ ] 10.1 Run `terraform fmt` on all .tf files
-- [ ] 10.2 Run `terraform validate` to check syntax
+- [x] 10.2 Run `terraform validate` to check syntax
 - [ ] 10.3 Run `terraform plan` with test configuration to verify:
   - [ ] 10.3.1 All resources have correct naming pattern
   - [ ] 10.3.2 All resources have standard tags

--- a/openspec/changes/standardize-resource-naming/tasks.md
+++ b/openspec/changes/standardize-resource-naming/tasks.md
@@ -94,27 +94,27 @@
 
 ## 9. Documentation Updates
 
-- [ ] 9.1 Update `openspec/project.md` with new naming convention
-- [ ] 9.2 Update backend-*.hcl header comments with new pattern
-- [ ] 9.3 Add migration guide to release notes
+- [x] 9.1 Update `openspec/project.md` with new naming convention
+- [x] 9.2 Update backend-*.hcl header comments with new pattern
+- [x] 9.3 Add migration guide (see `migration.md` in this directory)
 
 ## 10. Validation and Testing
 
 - [x] 10.1 Run `terraform fmt` on all .tf files
 - [x] 10.2 Run `terraform validate` to check syntax
-- [ ] 10.3 Run `terraform plan` with test configuration to verify:
+- [ ] 10.3 Run `terraform plan` with test configuration to verify: _(requires live AWS credentials)_
   - [ ] 10.3.1 All resources have correct naming pattern
   - [ ] 10.3.2 All resources have standard tags
   - [ ] 10.3.3 No hardcoded `lablink-` prefixes remain
-- [ ] 10.4 Verify tag query works:
+- [ ] 10.4 Verify tag query works: _(post-deployment)_
   ```bash
   aws resourcegroupstaggingapi get-resources --tag-filters Key=Project,Values={deployment_name}
   ```
-- [ ] 10.5 Test multi-deployment scenario (if possible in ci-test)
+- [ ] 10.5 Test multi-deployment scenario (if possible in ci-test) _(post-deployment)_
 
 ## 11. Final Verification
 
 - [x] 11.1 Search codebase for remaining `lablink_` (underscore) patterns
 - [x] 11.2 Search codebase for remaining hardcoded `lablink-` prefixes
-- [ ] 11.3 Verify all resources in terraform plan use new naming
-- [ ] 11.4 Update GitHub issue #28 with completion status
+- [ ] 11.3 Verify all resources in terraform plan use new naming _(requires live AWS credentials)_
+- [ ] 11.4 Update GitHub issue #28 with completion status _(post-merge)_

--- a/openspec/changes/standardize-resource-naming/tasks.md
+++ b/openspec/changes/standardize-resource-naming/tasks.md
@@ -80,7 +80,7 @@
 
 ## 7. Configuration Updates
 
-- [ ] 7.1 Update `backend-*.hcl` files with new variable documentation
+- [x] 7.1 Update `backend-*.hcl` files with new variable documentation
 - [x] 7.2 Update example config files:
   - [x] 7.2.1 Add monitoring section to `config/prod.example.yaml`
   - [x] 7.2.2 Add monitoring section to `config/ip-only.example.yaml`
@@ -100,7 +100,7 @@
 
 ## 10. Validation and Testing
 
-- [ ] 10.1 Run `terraform fmt` on all .tf files
+- [x] 10.1 Run `terraform fmt` on all .tf files
 - [x] 10.2 Run `terraform validate` to check syntax
 - [ ] 10.3 Run `terraform plan` with test configuration to verify:
   - [ ] 10.3.1 All resources have correct naming pattern
@@ -114,7 +114,7 @@
 
 ## 11. Final Verification
 
-- [ ] 11.1 Search codebase for remaining `lablink_` (underscore) patterns
-- [ ] 11.2 Search codebase for remaining hardcoded `lablink-` prefixes
+- [x] 11.1 Search codebase for remaining `lablink_` (underscore) patterns
+- [x] 11.2 Search codebase for remaining hardcoded `lablink-` prefixes
 - [ ] 11.3 Verify all resources in terraform plan use new naming
 - [ ] 11.4 Update GitHub issue #28 with completion status

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -62,7 +62,8 @@ LabLink Infrastructure Template is a GitHub template repository for deploying La
 ### Architecture Patterns
 
 **Multi-Environment Strategy:**
-- Resource suffix pattern: `{resource}-{environment}` (e.g., lablink-allocator-test)
+- Resource naming pattern: `{deployment_name}-{resource-type}-{environment}` (e.g., sleap-lablink-allocator-prod)
+- Two variables: `deployment_name` (required, kebab-case) and `environment` (dev, test, ci-test, prod)
 - Environment-specific backend configs: `backend-{env}.hcl`
 - Shared configuration with environment overrides
 
@@ -137,10 +138,12 @@ LabLink Infrastructure Template is a GitHub template repository for deploying La
 - **Research Software**: Custom software deployed via Docker containers (e.g., SLEAP for animal pose tracking)
 
 **AWS Resource Naming:**
-- Pattern: `{resource}-{suffix}` where suffix is environment name
-- Security Groups: `lablink-allocator-sg-{env}`, `lablink-client-sg-{env}`
-- EC2 Instances: `lablink-allocator-{env}`
-- IAM Roles: `lablink-client-iam-role-{env}`
+- Pattern: `{deployment_name}-{resource-type}-{environment}` (kebab-case everywhere)
+- Standard tags on all resources: `Name`, `Environment`, `Project`, `ManagedBy`, `Repository` (optional)
+- Security Groups: `{deployment}-allocator-sg-{env}`, `{deployment}-alb-sg-{env}`
+- EC2 Instances: `{deployment}-allocator-{env}`
+- IAM Roles: `{deployment}-allocator-role-{env}`
+- See issue #28 for complete resource naming table
 
 **Key Configuration Concepts:**
 - **machine_type**: AWS instance type for client VMs (e.g., g4dn.xlarge for GPU)
@@ -167,7 +170,7 @@ LabLink Infrastructure Template is a GitHub template repository for deploying La
 - config.yaml path is hardcoded: `lablink-infrastructure/config/config.yaml`
 - S3 bucket names must be globally unique across ALL AWS accounts
 - Terraform state must not be deleted while infrastructure exists
-- Environment suffix must be consistent across backend config and variable
+- `deployment_name` and `environment` must be consistent across backend config and Terraform variables
 
 **Security Requirements:**
 - Never commit secrets to repository (use GitHub secrets)


### PR DESCRIPTION
## Summary

- Adds OpenSpec change proposal for standardizing Terraform resource naming
- Addresses issue #28 with detailed spec, design decisions, and implementation tasks
- Enables multi-deployment support in same AWS account

## Changes

**New files in `openspec/changes/standardize-resource-naming/`:**
- `proposal.md` - Problem statement, breaking changes, impact analysis
- `design.md` - Technical decisions and rationale for naming scheme
- `specs/infrastructure/spec.md` - 4 requirements with 17 testable TDD scenarios
- `tasks.md` - 56 implementation tasks across 11 sections

## Key Decisions

1. **Two-variable naming**: `deployment_name` (required) + `environment`
2. **Format**: `{deployment}-{resource-type}-{environment}`
3. **Kebab-case everywhere** (including IAM resources)
4. **Standard tags**: Name, Environment, Project, ManagedBy, Repository

## Test plan

- [x] Run `openspec validate standardize-resource-naming --strict` - passed
- [ ] Team review of proposal and design decisions
- [ ] Approve before implementation begins

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)