### PR TITLE
fix: compress user_data to avoid 16KB limit

### DIFF
--- a/lablink-infrastructure/main.tf
+++ b/lablink-infrastructure/main.tf
@@ -228,7 +228,7 @@ resource "aws_instance" "lablink_allocator_server" {
   key_name             = aws_key_pair.lablink_key_pair.key_name
   iam_instance_profile = aws_iam_instance_profile.allocator_instance_profile.name
 
-  user_data = templatefile("${path.module}/user_data.sh", {
+  user_data_base64 = base64gzip(templatefile("${path.module}/user_data.sh", {
     ALLOCATOR_IMAGE_TAG       = local.allocator_image_tag
     RESOURCE_SUFFIX           = var.resource_suffix
     ALLOCATOR_PUBLIC_IP       = local.eip_public_ip
@@ -242,7 +242,7 @@ resource "aws_instance" "lablink_allocator_server" {
     SSL_PROVIDER              = local.ssl_provider
     SSL_EMAIL                 = local.ssl_email
     DOMAIN_NAME               = local.install_caddy ? local.dns_domain : ""
-  })
+  }))
 
   tags = {
     Name        = "lablink_allocator_server_${var.resource_suffix}"


### PR DESCRIPTION
## Summary

Compress EC2 user data with gzip to avoid exceeding the 16 KB size limit imposed by AWS.

## Changes

### Infrastructure Resources
- Modified `lablink-infrastructure/main.tf`: switched `user_data` to `user_data_base64` using `base64gzip()` to compress the templated user data script before passing it to the EC2 instance.

## Technical Details

AWS EC2 has a 16 KB limit on user data. As the `user_data.sh` template grew with additional configuration variables (config content, startup scripts, SSL settings), it risked exceeding this limit. Wrapping with `base64gzip()` compresses the payload, and EC2 natively decompresses gzipped user data at boot — no changes to the script itself are needed.

## Deployment Notes

- This change will **force replacement** of the EC2 instance on next `terraform apply`, since `user_data` and `user_data_base64` are different attributes.
- Plan accordingly for downtime during the instance recreation.

## Testing

- [ ] `terraform validate` passes
- [ ] `terraform plan` reviewed — confirms instance replacement only
- [ ] Deployed to ci-test environment and verified cloud-init runs successfully
- [ ] Allocator service starts and is reachable after instance recreation

🤖 Generated with [Claude Code](https://claude.com/claude-code)