### PR TITLE
fix: set ALB idle_timeout to 3600s for KasmVNC WebSocket

### DIFF
--- a/lablink-infrastructure/alb.tf
+++ b/lablink-infrastructure/alb.tf
@@ -73,6 +73,14 @@ resource "aws_lb" "allocator_alb" {
   security_groups    = [aws_security_group.alb_sg[0].id]
   subnets            = data.aws_subnets.default[0].ids
 
+  # KasmVNC traffic transits this LB as a WebSocket. The bundled noVNC viewer
+  # does not emit WS-level pings, and KasmVNC only sends framebuffer updates
+  # on pixel change — natural pauses in SLEAP (model loading, inference
+  # batches, frame review without input) produce >60s windows of zero bytes
+  # in both directions, which the ALB default (60s) silently closes. Match
+  # the allocator nginx's proxy_read_timeout intent with a long idle window.
+  idle_timeout = 3600
+
   enable_deletion_protection = false
 
   tags = merge(local.common_tags, {

--- a/lablink-infrastructure/alb.tf
+++ b/lablink-infrastructure/alb.tf
@@ -73,12 +73,7 @@ resource "aws_lb" "allocator_alb" {
   security_groups    = [aws_security_group.alb_sg[0].id]
   subnets            = data.aws_subnets.default[0].ids
 
-  # KasmVNC traffic transits this LB as a WebSocket. The bundled noVNC viewer
-  # does not emit WS-level pings, and KasmVNC only sends framebuffer updates
-  # on pixel change — natural pauses in SLEAP (model loading, inference
-  # batches, frame review without input) produce >60s windows of zero bytes
-  # in both directions, which the ALB default (60s) silently closes. Match
-  # the allocator nginx's proxy_read_timeout intent with a long idle window.
+  # KasmVNC WS has no app-level pings; AWS's 60s default drops idle pauses.
   idle_timeout = 3600
 
   enable_deletion_protection = false


### PR DESCRIPTION
## Summary

- The allocator ALB was using AWS's default `idle_timeout` of **60 seconds** — no `idle_timeout` was set on `aws_lb.allocator_alb`.
- KasmVNC's bundled noVNC viewer does not emit WS-level pings, and KasmVNC only sends framebuffer updates on pixel change. Natural pauses during SLEAP (model loading, inference batches, frame review without input) produce >60 s windows of zero bidirectional bytes, which the ALB silently closes — surfacing as a *"Disconnected"* toast in the viewer.
- The architecture diagram already documents the intent (`idle_timeout set in lablink-template`); this PR makes the code match.
- Set `idle_timeout = 3600` to align with the allocator nginx's `proxy_read_timeout 86400s` for the `/proxy/<token>` location. ALB hard max is 4000 s, 3600 s leaves headroom.

## Test plan

- [ ] `terraform plan` against an existing deployment shows only `idle_timeout` changing on `aws_lb.allocator_alb` (in-place update — no replacement).
- [ ] `terraform apply` succeeds; ALB attribute is updated in place with no connection drops.
- [ ] Run a SLEAP session through the assigned VM, leave it idle for 5+ minutes, confirm the noVNC viewer does not disconnect.
- [ ] DevTools → Network → WS row shows the WebSocket persisting past the 60 s mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)