### PR TITLE
fix: serve HTTPS origin so Cloudflare Full SSL mode works

### DIFF
--- a/lablink-infrastructure/README.md
+++ b/lablink-infrastructure/README.md
@@ -243,7 +243,7 @@ Each environment maintains separate Terraform state to avoid conflicts.
 **SSL Provider Options:**
 
 - `letsencrypt`: Caddy automatically obtains trusted Let's Encrypt certificates and serves HTTPS
-- `cloudflare`: CloudFlare proxy provides SSL termination (Caddy serves HTTP, CloudFlare adds HTTPS)
+- `cloudflare`: CloudFlare proxy provides edge SSL. Caddy serves the origin over HTTPS with a self-signed cert (`tls internal`), compatible with CloudFlare's recommended **Full** mode (Full does not validate the origin cert). Also serves HTTP for Flexible mode. Use Full, not Full (strict).
 - `acm`: AWS Certificate Manager via Application Load Balancer (enterprise-grade SSL)
 - `none`: HTTP only (no SSL) - for testing purposes only
 

--- a/lablink-infrastructure/config/cloudflare.example.yaml
+++ b/lablink-infrastructure/config/cloudflare.example.yaml
@@ -11,8 +11,10 @@
 # Setup:
 # 1. Deploy infrastructure (note allocator IP from output)
 # 2. Create A record in CloudFlare: lablink.example.com → {allocator_public_ip}
+#    (use the allocator's Elastic IP from `terraform output ec2_public_ip`)
 # 3. Enable CloudFlare proxy (orange cloud)
-# 4. SSL/TLS mode: Full (not Strict)
+# 4. SSL/TLS mode: Full (NOT Full (strict)). The origin serves a self-signed
+#    cert (Caddy "tls internal"); Full accepts it, Full (strict) would reject it.
 #
 # Access URL: https://lablink.example.com (CloudFlare provides SSL)
 

--- a/lablink-infrastructure/user_data.sh
+++ b/lablink-infrastructure/user_data.sh
@@ -80,9 +80,19 @@ ${DOMAIN_NAME} {
 EOF
   elif [ "${SSL_PROVIDER}" = "cloudflare" ]; then
     cat <<EOF > /etc/caddy/Caddyfile
-# CloudFlare DNS + SSL (managed in CloudFlare)
-# Caddy serves HTTP, CloudFlare proxies with SSL
+# CloudFlare DNS + SSL (managed in CloudFlare).
+# CloudFlare terminates TLS at its edge and then connects back to this origin,
+# matching the visitor's protocol. In the recommended "Full" mode it connects
+# over HTTPS on port 443 and does NOT validate the origin certificate, so Caddy
+# serves a self-signed cert via "tls internal" (no ACME, no Let's Encrypt rate
+# limits). The plain-HTTP block keeps the origin reachable if CloudFlare is set
+# to "Flexible" or a visitor arrives over HTTP.
 http://${DOMAIN_NAME} {
+    reverse_proxy localhost:5000
+}
+
+https://${DOMAIN_NAME} {
+    tls internal
     reverse_proxy localhost:5000
 }
 EOF


### PR DESCRIPTION
## Problem

The `cloudflare` SSL provider configures Caddy to serve **plain HTTP on port 80 only** — a Cloudflare **Flexible**-mode origin. But our own docs (and Cloudflare's recommendation) tell users to set the SSL/TLS mode to **Full**, where Cloudflare connects to the origin over **HTTPS on port 443**.

With nothing listening on 443, Cloudflare can't reach the origin and returns **Error 521 ("web server is down")** — even though the allocator container on `:5000` is perfectly healthy.

Verified live against a Full-mode deployment:

```
HTTPS via Cloudflare →  HTTP/2 521   server: cloudflare
HTTP  via Cloudflare →  301 → https  (Always Use HTTPS on)
```

Per the [Cloudflare Full mode docs](https://developers.cloudflare.com/ssl/origin-configuration/ssl-modes/full/): Cloudflare connects to the origin over HTTPS and **does not validate** the origin certificate ("It can be expired, self-signed, or not even have a matching CN/SAN entry").

## Fix

Configure Caddy to also serve **HTTPS:443 with a self-signed cert** via `tls internal`:

```caddy
http://${DOMAIN_NAME}  { reverse_proxy localhost:5000 }
https://${DOMAIN_NAME} { tls internal
                         reverse_proxy localhost:5000 }
```

- `tls internal` → Caddy's own self-signed CA, so **no ACME / no Let's Encrypt rate limits** (consistent with the "no rate limits" selling point of the Cloudflare path).
- Full mode accepts the self-signed cert; **Full (strict)** would not — so the docs steer users to **Full**, not Full (strict).
- The HTTP:80 block is kept so the origin still works in Flexible mode / for plain-HTTP visitors.

## Also

Corrected the now-inaccurate "Caddy serves HTTP" notes in `lablink-infrastructure/README.md` and `config/cloudflare.example.yaml`, and added a pointer to find the origin IP for the Cloudflare A record.

## Operator notes

- Still requires the Cloudflare **A record** to point at the allocator's Elastic IP (proxy on) and **SSL/TLS mode = Full**. These are dashboard steps, unchanged.
- `user_data.sh` changes force the allocator EC2 instance to be **replaced** on `terraform apply`. For an already-running box, the Caddyfile can be swapped in place + `systemctl restart caddy` for an immediate fix.
- This is the template repo — to reach a `lablink` CLI deploy it needs a new release tag + `TEMPLATE_VERSION`/`TEMPLATE_SHA256` bump in the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)